### PR TITLE
Fix session validation and update Python version support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   lint:
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: "3.13"
           cache: "pip"
           cache-dependency-path: "setup.py"
       - name: lint
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: "3.13"
           cache: "pip"
           cache-dependency-path: "setup.py"
       - name: fmtcheck
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
+        python-version: [3.9, "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,7 @@ jobs:
         run: make fmtcheck
 
   build:
-    # Specific ubuntu version to support python 3.6 testing
-    # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877 for details
-    # move to ubuntu-latest when we drop 3.6
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version: [3.9, "3.10", "3.11", "3.12", "3.13"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 0.0.9 - 2025-10-01
-* Fix bug in session validation
+* [#16](https://github.com/Dintero/Dintero.Python.SDK/issues/16) Fix bug in session validation
 
 ## 0.0.8 - 2023-07-13
 * Change link to documentation for creating Checkout client

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 0.0.9 - 2025-10-01
+* Fix bug in session validation
 
 ## 0.0.8 - 2023-07-13
 * Change link to documentation for creating Checkout client

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,13 @@
 VENV_NAME?=venv
-PIP?=pip
-PYTHON?=python
+PYTHON?=python3
 
 venv: $(VENV_NAME)/bin/activate
 
 $(VENV_NAME)/bin/activate: setup.py
-	$(PIP) install --upgrade pip virtualenv
-	@test -d $(VENV_NAME) || $(PYTHON) -m virtualenv --clear $(VENV_NAME)
+	@test -d $(VENV_NAME) || $(PYTHON) -m venv $(VENV_NAME)
 	${VENV_NAME}/bin/python -m pip install -U pip tox
 	${VENV_NAME}/bin/python -m pip install -e .
+	${VENV_NAME}/bin/python -m pip install -e '.[dev]'
 	@touch $(VENV_NAME)/bin/activate
 
 test: venv

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ pip install --upgrade dintero
 
 ### Requirements
 
-* Python 3.6+
+* Python 3.9+
 
 ## Using the SDK
 

--- a/dintero/validator.py
+++ b/dintero/validator.py
@@ -2,9 +2,16 @@ from dintero.error import InvalidFieldError
 
 
 def validate_session(session):
-    if session["order"]["amount"] != sum(
-        [item["amount"] for item in session["order"]["items"]]
-    ):
+    """
+    Validates that the session's total order amount matches the sum of the
+    item amounts plus the shipping amount.
+    """
+    order = session.get("order", {})
+    items_total = sum(item.get("amount", 0) for item in order.get("items", []))
+    shipping_amount = order.get("shipping_option", {}).get("amount", 0)
+
+    if order.get("amount") != items_total + shipping_amount:
         raise InvalidFieldError(
-            "order.amount doesn't match sum of order.items", "order.amount"
+            "order.amount does not match the sum of order.items and shipping_option.amount",
+            "order.amount",
         )

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,9 @@ with open(os.path.join(this_directory, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 version_contents = {}
 
-with open(os.path.join(this_directory, "dintero", "version.py"), encoding="utf-8") as f:
+with open(
+    os.path.join(this_directory, "dintero", "version.py"), encoding="utf-8"
+) as f:
     exec(f.read(), version_contents)
 
 setup(
@@ -53,8 +55,6 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
-        "Programming Language :: Python :: 3.14",
-        "Programming Language :: Python :: 3.15",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],

--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,7 @@ with open(os.path.join(this_directory, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 version_contents = {}
 
-with open(
-    os.path.join(this_directory, "dintero", "version.py"), encoding="utf-8"
-) as f:
+with open(os.path.join(this_directory, "dintero", "version.py"), encoding="utf-8") as f:
     exec(f.read(), version_contents)
 
 setup(
@@ -34,7 +32,7 @@ setup(
             "pytest",
         ]
     },
-    python_requires=">=3.6",
+    python_requires=">=3.9",
     project_urls={
         "Bug Tracker": "https://github.com/dintero/Dintero.Python.SDK/issues",
         "Documentation": "https://docs.dintero.com",
@@ -52,6 +50,11 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
+        "Programming Language :: Python :: 3.15",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,0 +1,67 @@
+import pytest
+
+from dintero.error import InvalidFieldError
+from dintero.validator import validate_session
+
+
+def test_validate_session_valid():
+    """
+    Should not raise an exception when the order amount matches the sum of
+    the item amounts.
+    """
+    session = {
+        "order": {
+            "amount": 60000,
+            "items": [
+                {"amount": 10000},
+                {"amount": 20000},
+                {"amount": 30000},
+            ],
+        }
+    }
+    validate_session(session)
+
+
+def test_validate_session_shipping_option_valid():
+    """
+    Should not raise an exception when the order amount matches the sum of
+    the item amounts and shipping option.
+    """
+    session = {
+        "order": {
+            "amount": 70000,
+            "items": [
+                {"amount": 10000},
+                {"amount": 20000},
+                {"amount": 30000},
+            ],
+            "shipping_option": {
+                "amount": 10000,
+            },
+        },
+    }
+    validate_session(session)
+
+
+def test_validate_session_invalid_raises_error():
+    """
+    Should raise InvalidFieldError when the order amount does not match the
+    sum of the item amounts.
+    """
+    session = {
+        "order": {
+            "amount": 50000,
+            "items": [
+                {"amount": 10000},
+                {"amount": 20000},
+                {"amount": 30000},
+            ],
+        }
+    }
+    with pytest.raises(InvalidFieldError) as excinfo:
+        validate_session(session)
+    assert (
+        "order.amount does not match the sum of order.items and shipping_option.amount"
+        in str(excinfo.value)
+    )
+    assert excinfo.value.field == "order.amount"

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
     fmt
     lint
-    py{310,39,38,37,36,py3}
+    py{315,314,313,312,311,310,39}
 skip_missing_interpreters = true
 
 [tool:pytest]
@@ -19,7 +19,7 @@ deps =
     pytest >= 6.0.0
     pytest-cov >= 2.12.1
 depends =
-    report: py310
+    report: py315
 commands = pytest --cov --cov-append
 
 [testenv:report]
@@ -31,14 +31,14 @@ commands =
 
 [testenv:fmt]
 description = run code formatting using black
-basepython = python3.10
+basepython = python3.15
 deps = black==23.7.0
 commands = black . {posargs}
 skip_install = true
 
 [testenv:lint]
 description = run static analysis and style check using flake8
-basepython = python3.10
+basepython = python3.15
 deps = flake8
 commands = python -m flake8 --show-source dintero tests setup.py
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
     fmt
     lint
-    py{315,314,313,312,311,310,39}
+    py{313,312,311,310,39}
 skip_missing_interpreters = true
 
 [tool:pytest]
@@ -19,7 +19,7 @@ deps =
     pytest >= 6.0.0
     pytest-cov >= 2.12.1
 depends =
-    report: py315
+    report: py313
 commands = pytest --cov --cov-append
 
 [testenv:report]
@@ -31,14 +31,14 @@ commands =
 
 [testenv:fmt]
 description = run code formatting using black
-basepython = python3.15
+basepython = python3.13
 deps = black==23.7.0
 commands = black . {posargs}
 skip_install = true
 
 [testenv:lint]
 description = run static analysis and style check using flake8
-basepython = python3.15
+basepython = python3.13
 deps = flake8
 commands = python -m flake8 --show-source dintero tests setup.py
 skip_install = true


### PR DESCRIPTION
Update session validation to include shipping amount in total. Raise
minimum Python version to 3.9 and add support for 3.11–3.15. Update
Makefile to use python3 and venv. Update tox environments.

Closes https://github.com/Dintero/Dintero.Python.SDK/issues/16
